### PR TITLE
Use env -S to split the parameter string

### DIFF
--- a/bin/commonmark
+++ b/bin/commonmark
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r esm
+#!/usr/bin/env -S node -r esm
 "use strict";
 
 import util from "util";


### PR DESCRIPTION
On Linux, the shebang feeds the parameters to the command (here, env) as a single parameter string.

Thus, running this script on Linux yielded an error:

> env: ‘node -r esm’: No such file or directory
> env: use -[v]S to pass options in shebang lines

Using -S tells env to split the string it receives and feed the parameters to the program it forks.